### PR TITLE
Prototype for  IServicemessagecontext

### DIFF
--- a/Libraries/Opc.Ua.Client.ComplexTypes/Types/BaseComplexType.cs
+++ b/Libraries/Opc.Ua.Client.ComplexTypes/Types/BaseComplexType.cs
@@ -971,7 +971,7 @@ namespace Opc.Ua.Client.ComplexTypes
         #endregion Protected Fields
 
         #region Private Fields
-        private ServiceMessageContext m_context;
+        private IServiceMessageContext m_context;
         private StructureBaseDataType m_structureBaseType;
         private XmlQualifiedName m_xmlName;
         #endregion Private Fields

--- a/Libraries/Opc.Ua.Client/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session.cs
@@ -547,7 +547,7 @@ namespace Opc.Ua.Client
         /// <summary>
         /// Gets the factory used to create encodeable objects that the server understands.
         /// </summary>
-        public EncodeableFactory Factory => m_factory;
+        public IEncodeableFactory Factory => m_factory;
 
         /// <summary>
         /// Gets the cache of the server's type tree.
@@ -4585,7 +4585,7 @@ namespace Opc.Ua.Client
         private StringCollection m_preferredLocales;
         private NamespaceTable m_namespaceUris;
         private StringTable m_serverUris;
-        private EncodeableFactory m_factory;
+        private IEncodeableFactory m_factory;
         private SystemContext m_systemContext;
         private NodeCache m_nodeCache;
         private ApplicationConfiguration m_configuration;

--- a/Libraries/Opc.Ua.Client/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session.cs
@@ -203,7 +203,7 @@ namespace Opc.Ua.Client
             }
 
             // initialize the message context.
-            ServiceMessageContext messageContext = channel.MessageContext;
+            IServiceMessageContext messageContext = channel.MessageContext;
 
             if (messageContext != null)
             {
@@ -807,7 +807,7 @@ namespace Opc.Ua.Client
             }
 
             // create message context.
-            ServiceMessageContext messageContext = configuration.CreateMessageContext(true);
+            IServiceMessageContext messageContext = configuration.CreateMessageContext(true);
 
             // update endpoint description using the discovery endpoint.
             if (endpoint.UpdateBeforeConnect && connection == null)
@@ -948,7 +948,7 @@ namespace Opc.Ua.Client
         /// <returns>The new session object.</returns>
         public static Session Recreate(Session template)
         {
-            ServiceMessageContext messageContext = template.m_configuration.CreateMessageContext();
+            var messageContext = template.m_configuration.CreateMessageContext();
             messageContext.Factory = template.Factory;
 
             // create the channel object used to connect to the server.
@@ -997,7 +997,7 @@ namespace Opc.Ua.Client
         /// <returns>The new session object.</returns>
         public static Session Recreate(Session template, ITransportWaitingConnection connection)
         {
-            ServiceMessageContext messageContext = template.m_configuration.CreateMessageContext();
+            var messageContext = template.m_configuration.CreateMessageContext();
             messageContext.Factory = template.Factory;
 
             // create the channel object used to connect to the server.

--- a/Libraries/Opc.Ua.Client/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session.cs
@@ -572,7 +572,7 @@ namespace Opc.Ua.Client
         /// <summary>
         /// Gets the data type system dictionaries in use.
         /// </summary>
-        public Dictionary<NodeId, DataDictionary> DataTypeSystem => m_dictionaries;
+        public IReadOnlyDictionary<NodeId, DataDictionary> DataTypeSystem => m_dictionaries;
 
         /// <summary>
         /// Gets the subscriptions owned by the session.

--- a/Libraries/Opc.Ua.Gds.Client.Common/LocalDiscoveryServerClient.cs
+++ b/Libraries/Opc.Ua.Gds.Client.Common/LocalDiscoveryServerClient.cs
@@ -67,7 +67,7 @@ namespace Opc.Ua.Gds.Client
         #region Public Properties
         public ApplicationConfiguration ApplicationConfiguration { get; private set; }
 
-        public ServiceMessageContext MessageContext { get; private set; }
+        public IServiceMessageContext MessageContext { get; private set; }
 
         public string[] PreferredLocales { get; set; }
 
@@ -412,7 +412,7 @@ namespace Opc.Ua.Gds.Client
                 throw new ArgumentException("Not a valid URL.", nameof(endpointUrl));
             }
 
-            ServiceMessageContext context = ApplicationConfiguration.CreateMessageContext();
+            IServiceMessageContext context = ApplicationConfiguration.CreateMessageContext();
 
             EndpointConfiguration configuration = EndpointConfiguration.Create(ApplicationConfiguration);
 

--- a/Libraries/Opc.Ua.PubSub/Encoding/JsonNetworkMessage.cs
+++ b/Libraries/Opc.Ua.PubSub/Encoding/JsonNetworkMessage.cs
@@ -178,7 +178,7 @@ namespace Opc.Ua.PubSub.Encoding
         /// </summary>
         /// <param name="messageContext">The context.</param>
         /// <param name="writer">The stream to use.</param>
-        public override void Encode(ServiceMessageContext messageContext, StreamWriter writer)
+        public override void Encode(IServiceMessageContext messageContext, StreamWriter writer)
         {
             bool topLevelIsArray = !HasNetworkMessageHeader && !HasSingleDataSetMessage;
 

--- a/Libraries/Opc.Ua.PubSub/Encoding/UadpNetworkMessage.cs
+++ b/Libraries/Opc.Ua.PubSub/Encoding/UadpNetworkMessage.cs
@@ -279,7 +279,7 @@ namespace Opc.Ua.PubSub.Encoding
         /// </summary>
         /// <param name="messageContext">The system context.</param>
         /// <param name="writer">The stream to use.</param>
-        public override void Encode(ServiceMessageContext messageContext, StreamWriter writer)
+        public override void Encode(IServiceMessageContext messageContext, StreamWriter writer)
         {
             using (BinaryEncoder encoder = new BinaryEncoder(writer.BaseStream, messageContext))
             {

--- a/Libraries/Opc.Ua.PubSub/UaNetworkMessage.cs
+++ b/Libraries/Opc.Ua.PubSub/UaNetworkMessage.cs
@@ -94,7 +94,7 @@ namespace Opc.Ua.PubSub
         /// </summary>
         /// <param name="messageContext">The context.</param>
         /// <param name="writer">The stream to use.</param>
-        public abstract void Encode(ServiceMessageContext messageContext, StreamWriter writer);
+        public abstract void Encode(IServiceMessageContext messageContext, StreamWriter writer);
 
         /// <summary>
         /// Decodes the message

--- a/Libraries/Opc.Ua.Server/Configuration/TrustList.cs
+++ b/Libraries/Opc.Ua.Server/Configuration/TrustList.cs
@@ -542,7 +542,7 @@ namespace Opc.Ua.Server
             TrustListDataType trustList
             )
         {
-            ServiceMessageContext messageContext = new ServiceMessageContext() {
+            IServiceMessageContext messageContext = new ServiceMessageContext() {
                 NamespaceUris = context.NamespaceUris,
                 ServerUris = context.ServerUris,
                 Factory = context.EncodeableFactory
@@ -559,7 +559,7 @@ namespace Opc.Ua.Server
             Stream strm)
         {
             TrustListDataType trustList = new TrustListDataType();
-            ServiceMessageContext messageContext = new ServiceMessageContext() {
+            IServiceMessageContext messageContext = new ServiceMessageContext() {
                 NamespaceUris = context.NamespaceUris,
                 ServerUris = context.ServerUris,
                 Factory = context.EncodeableFactory

--- a/Libraries/Opc.Ua.Server/Server/IServerInternal.cs
+++ b/Libraries/Opc.Ua.Server/Server/IServerInternal.cs
@@ -78,7 +78,7 @@ namespace Opc.Ua.Server
         /// The factory used to create encodeable objects that the server understands.
         /// </summary>
         /// <value>The factory.</value>
-        EncodeableFactory Factory { get; }
+        IEncodeableFactory Factory { get; }
 
         /// <summary>
         /// The datatypes, object types and variable types known to the server.

--- a/Libraries/Opc.Ua.Server/Server/IServerInternal.cs
+++ b/Libraries/Opc.Ua.Server/Server/IServerInternal.cs
@@ -54,7 +54,7 @@ namespace Opc.Ua.Server
         /// The context to use when serializing/deserializing extension objects.
         /// </summary>
         /// <value>The message context.</value>
-        ServiceMessageContext MessageContext { get; }
+        IServiceMessageContext MessageContext { get; }
 
         /// <summary>
         /// The default system context for the server.

--- a/Libraries/Opc.Ua.Server/Server/ServerInternalData.cs
+++ b/Libraries/Opc.Ua.Server/Server/ServerInternalData.cs
@@ -68,7 +68,7 @@ namespace Opc.Ua.Server
         public ServerInternalData(
             ServerProperties                     serverDescription,
             ApplicationConfiguration             configuration,
-            ServiceMessageContext                messageContext,
+            IServiceMessageContext                messageContext,
             CertificateValidator                 certificateValidator,
             X509Certificate2                     instanceCertificate)
         {
@@ -212,7 +212,7 @@ namespace Opc.Ua.Server
         /// The context to use when serializing/deserializing extension objects.
         /// </summary>
         /// <value>The message context.</value>
-        public ServiceMessageContext MessageContext
+        public IServiceMessageContext MessageContext
         {
             get { return m_messageContext; }
         }
@@ -767,7 +767,7 @@ namespace Opc.Ua.Server
         private ServerProperties m_serverDescription;
         private ApplicationConfiguration m_configuration;
         private List<Uri> m_endpointAddresses;
-        private ServiceMessageContext m_messageContext;
+        private IServiceMessageContext m_messageContext;
         private ServerSystemContext m_defaultSystemContext;
         private NamespaceTable m_namespaceUris;
         private StringTable m_serverUris;

--- a/Libraries/Opc.Ua.Server/Server/ServerInternalData.cs
+++ b/Libraries/Opc.Ua.Server/Server/ServerInternalData.cs
@@ -248,7 +248,7 @@ namespace Opc.Ua.Server
         /// The factory used to create encodeable objects that the server understands.
         /// </summary>
         /// <value>The factory.</value>
-        public EncodeableFactory Factory
+        public IEncodeableFactory Factory
         {
             get { return m_factory; }
         }
@@ -771,7 +771,7 @@ namespace Opc.Ua.Server
         private ServerSystemContext m_defaultSystemContext;
         private NamespaceTable m_namespaceUris;
         private StringTable m_serverUris;
-        private EncodeableFactory m_factory;
+        private IEncodeableFactory m_factory;
         private TypeTable m_typeTree;
 
 #if LEGACY_CORENODEMANAGER

--- a/Stack/Opc.Ua.Bindings.Https/Stack/Https/HttpsTransportChannel.cs
+++ b/Stack/Opc.Ua.Bindings.Https/Stack/Https/HttpsTransportChannel.cs
@@ -69,7 +69,7 @@ namespace Opc.Ua.Bindings
         public EndpointConfiguration EndpointConfiguration => m_settings.Configuration;
 
         /// <inheritdoc/>
-        public ServiceMessageContext MessageContext => m_quotas.MessageContext;
+        public IServiceMessageContext MessageContext => m_quotas.MessageContext;
 
         /// <inheritdoc/>
         public ChannelToken CurrentToken => null;
@@ -347,24 +347,24 @@ namespace Opc.Ua.Bindings
             m_operationTimeout = settings.Configuration.OperationTimeout;
 
             // initialize the quotas.
-            m_quotas = new ChannelQuotas();
+            m_quotas = new ChannelQuotas {
+                MaxBufferSize = m_settings.Configuration.MaxBufferSize,
+                MaxMessageSize = m_settings.Configuration.MaxMessageSize,
+                ChannelLifetime = m_settings.Configuration.ChannelLifetime,
+                SecurityTokenLifetime = m_settings.Configuration.SecurityTokenLifetime,
 
-            m_quotas.MaxBufferSize = m_settings.Configuration.MaxBufferSize;
-            m_quotas.MaxMessageSize = m_settings.Configuration.MaxMessageSize;
-            m_quotas.ChannelLifetime = m_settings.Configuration.ChannelLifetime;
-            m_quotas.SecurityTokenLifetime = m_settings.Configuration.SecurityTokenLifetime;
+                MessageContext = new ServiceMessageContext {
+                    MaxArrayLength = m_settings.Configuration.MaxArrayLength,
+                    MaxByteStringLength = m_settings.Configuration.MaxByteStringLength,
+                    MaxMessageSize = m_settings.Configuration.MaxMessageSize,
+                    MaxStringLength = m_settings.Configuration.MaxStringLength,
+                    NamespaceUris = m_settings.NamespaceUris,
+                    ServerUris = new StringTable(),
+                    Factory = m_settings.Factory
+                },
 
-            m_quotas.MessageContext = new ServiceMessageContext();
-
-            m_quotas.MessageContext.MaxArrayLength = m_settings.Configuration.MaxArrayLength;
-            m_quotas.MessageContext.MaxByteStringLength = m_settings.Configuration.MaxByteStringLength;
-            m_quotas.MessageContext.MaxMessageSize = m_settings.Configuration.MaxMessageSize;
-            m_quotas.MessageContext.MaxStringLength = m_settings.Configuration.MaxStringLength;
-            m_quotas.MessageContext.NamespaceUris = m_settings.NamespaceUris;
-            m_quotas.MessageContext.ServerUris = new StringTable();
-            m_quotas.MessageContext.Factory = m_settings.Factory;
-
-            m_quotas.CertificateValidator = settings.CertificateValidator;
+                CertificateValidator = settings.CertificateValidator
+            };
         }
 
         private Uri m_url;

--- a/Stack/Opc.Ua.Bindings.Https/Stack/Https/HttpsTransportListener.cs
+++ b/Stack/Opc.Ua.Bindings.Https/Stack/Https/HttpsTransportListener.cs
@@ -154,23 +154,24 @@ namespace Opc.Ua.Bindings
             var configuration = settings.Configuration;
 
             // initialize the quotas.
-            m_quotas = new ChannelQuotas();
-            m_quotas.MaxBufferSize = configuration.MaxBufferSize;
-            m_quotas.MaxMessageSize = configuration.MaxMessageSize;
-            m_quotas.ChannelLifetime = configuration.ChannelLifetime;
-            m_quotas.SecurityTokenLifetime = configuration.SecurityTokenLifetime;
+            m_quotas = new ChannelQuotas {
+                MaxBufferSize = configuration.MaxBufferSize,
+                MaxMessageSize = configuration.MaxMessageSize,
+                ChannelLifetime = configuration.ChannelLifetime,
+                SecurityTokenLifetime = configuration.SecurityTokenLifetime,
 
-            m_quotas.MessageContext = new ServiceMessageContext();
+                MessageContext = new ServiceMessageContext {
+                    MaxArrayLength = configuration.MaxArrayLength,
+                    MaxByteStringLength = configuration.MaxByteStringLength,
+                    MaxMessageSize = configuration.MaxMessageSize,
+                    MaxStringLength = configuration.MaxStringLength,
+                    NamespaceUris = settings.NamespaceUris,
+                    ServerUris = new StringTable(),
+                    Factory = settings.Factory
+                },
 
-            m_quotas.MessageContext.MaxArrayLength = configuration.MaxArrayLength;
-            m_quotas.MessageContext.MaxByteStringLength = configuration.MaxByteStringLength;
-            m_quotas.MessageContext.MaxMessageSize = configuration.MaxMessageSize;
-            m_quotas.MessageContext.MaxStringLength = configuration.MaxStringLength;
-            m_quotas.MessageContext.NamespaceUris = settings.NamespaceUris;
-            m_quotas.MessageContext.ServerUris = new StringTable();
-            m_quotas.MessageContext.Factory = settings.Factory;
-
-            m_quotas.CertificateValidator = settings.CertificateValidator;
+                CertificateValidator = settings.CertificateValidator
+            };
 
             // save the callback to the server.
             m_callback = callback;

--- a/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
+++ b/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
@@ -250,7 +250,7 @@ namespace Opc.Ua
         private XmlElementCollection m_extensions;
         private string m_sourceFilePath;
 
-        private ServiceMessageContext m_messageContext;
+        private IServiceMessageContext m_messageContext;
         private CertificateValidator m_certificateValidator;
         private Dictionary<string, object> m_properties;
         #endregion

--- a/Stack/Opc.Ua.Core/Schema/UANodeSetHelpers.cs
+++ b/Stack/Opc.Ua.Core/Schema/UANodeSetHelpers.cs
@@ -367,10 +367,11 @@ namespace Opc.Ua.Export
         /// </summary>
         private XmlEncoder CreateEncoder(ISystemContext context)
         {
-            ServiceMessageContext messageContext = new ServiceMessageContext();
-            messageContext.NamespaceUris = context.NamespaceUris;
-            messageContext.ServerUris = context.ServerUris;
-            messageContext.Factory = context.EncodeableFactory;
+            IServiceMessageContext messageContext = new ServiceMessageContext() {
+                NamespaceUris = context.NamespaceUris,
+                ServerUris = context.ServerUris,
+                Factory = context.EncodeableFactory
+            };
 
             XmlEncoder encoder = new XmlEncoder(messageContext);
 
@@ -984,8 +985,7 @@ namespace Opc.Ua.Export
             if (source.Field != null)
             {
                 // check if definition is for enumeration or structure.
-                bool isStructure = Array.Exists<DataTypeField>(source.Field, delegate (DataTypeField fieldLookup)
-                {
+                bool isStructure = Array.Exists<DataTypeField>(source.Field, delegate (DataTypeField fieldLookup) {
                     return fieldLookup.Value == -1;
                 });
 

--- a/Stack/Opc.Ua.Core/Stack/Bindings/BaseBinding.cs
+++ b/Stack/Opc.Ua.Core/Stack/Bindings/BaseBinding.cs
@@ -26,14 +26,14 @@ namespace Opc.Ua.Bindings
             EncodeableFactory factory,
             EndpointConfiguration configuration)
         {
-            m_messageContext = new ServiceMessageContext();
-
-            m_messageContext.MaxStringLength = configuration.MaxStringLength;
-            m_messageContext.MaxByteStringLength = configuration.MaxByteStringLength;
-            m_messageContext.MaxArrayLength = configuration.MaxArrayLength;
-            m_messageContext.MaxMessageSize = configuration.MaxMessageSize;
-            m_messageContext.Factory = factory;
-            m_messageContext.NamespaceUris = namespaceUris;
+            m_messageContext = new ServiceMessageContext {
+                MaxStringLength = configuration.MaxStringLength,
+                MaxByteStringLength = configuration.MaxByteStringLength,
+                MaxArrayLength = configuration.MaxArrayLength,
+                MaxMessageSize = configuration.MaxMessageSize,
+                Factory = factory,
+                NamespaceUris = namespaceUris
+            };
         }
         #endregion
 
@@ -41,7 +41,7 @@ namespace Opc.Ua.Bindings
         /// <summary>
         /// The message context to use with the binding.
         /// </summary>
-        public ServiceMessageContext MessageContext
+        public IServiceMessageContext MessageContext
         {
             get { return m_messageContext; }
             set { m_messageContext = value; }
@@ -49,7 +49,7 @@ namespace Opc.Ua.Bindings
         #endregion
 
         #region Private Fields
-        private ServiceMessageContext m_messageContext;
+        private IServiceMessageContext m_messageContext;
         #endregion
     }
 }

--- a/Stack/Opc.Ua.Core/Stack/Bindings/BaseBinding.cs
+++ b/Stack/Opc.Ua.Core/Stack/Bindings/BaseBinding.cs
@@ -23,7 +23,7 @@ namespace Opc.Ua.Bindings
         /// </summary>
         protected BaseBinding(
             NamespaceTable namespaceUris,
-            EncodeableFactory factory,
+            IEncodeableFactory factory,
             EndpointConfiguration configuration)
         {
             m_messageContext = new ServiceMessageContext {

--- a/Stack/Opc.Ua.Core/Stack/Client/ClientBase.cs
+++ b/Stack/Opc.Ua.Core/Stack/Client/ClientBase.cs
@@ -105,7 +105,7 @@ namespace Opc.Ua
         /// The message context used when serializing messages.
         /// </summary>
         /// <value>The message context.</value>
-        public ServiceMessageContext MessageContext
+        public IServiceMessageContext MessageContext
         {
             get
             {

--- a/Stack/Opc.Ua.Core/Stack/Client/DiscoveryClient.cs
+++ b/Stack/Opc.Ua.Core/Stack/Client/DiscoveryClient.cs
@@ -298,7 +298,7 @@ namespace Opc.Ua
         public static ITransportChannel Create(
             Uri discoveryUrl,
             EndpointConfiguration endpointConfiguration,
-            ServiceMessageContext messageContext,
+            IServiceMessageContext messageContext,
             X509Certificate2 clientCertificate = null)
         {
             // create a dummy description.
@@ -327,7 +327,7 @@ namespace Opc.Ua
             ApplicationConfiguration configuration,
             ITransportWaitingConnection connection,
             EndpointConfiguration endpointConfiguration,
-            ServiceMessageContext messageContext,
+            IServiceMessageContext messageContext,
             X509Certificate2 clientCertificate = null)
         {
             // create a default description.
@@ -358,7 +358,7 @@ namespace Opc.Ua
             ApplicationConfiguration configuration,
             Uri discoveryUrl,
             EndpointConfiguration endpointConfiguration,
-            ServiceMessageContext messageContext,
+            IServiceMessageContext messageContext,
             X509Certificate2 clientCertificate = null)
         {
             // create a default description.

--- a/Stack/Opc.Ua.Core/Stack/Client/RegistrationClient.cs
+++ b/Stack/Opc.Ua.Core/Stack/Client/RegistrationClient.cs
@@ -72,7 +72,7 @@ namespace Opc.Ua
             EndpointDescription description,
             EndpointConfiguration endpointConfiguration,
             X509Certificate2 clientCertificate,
-            ServiceMessageContext messageContext)
+            IServiceMessageContext messageContext)
         {
             // create a UA binary channel.
             ITransportChannel channel = CreateUaBinaryChannel(

--- a/Stack/Opc.Ua.Core/Stack/Client/SessionChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Client/SessionChannel.cs
@@ -34,7 +34,7 @@ namespace Opc.Ua
             EndpointDescription description,
             EndpointConfiguration endpointConfiguration,
             X509Certificate2 clientCertificate,
-            ServiceMessageContext messageContext)
+            IServiceMessageContext messageContext)
         {
             return Create(configuration, description, endpointConfiguration, clientCertificate, null, messageContext);
         }
@@ -55,7 +55,7 @@ namespace Opc.Ua
             EndpointConfiguration endpointConfiguration,
             X509Certificate2 clientCertificate,
             X509Certificate2Collection clientCertificateChain,
-            ServiceMessageContext messageContext)
+            IServiceMessageContext messageContext)
         {
             // create a UA binary channel.
             ITransportChannel channel = CreateUaBinaryChannel(
@@ -87,7 +87,7 @@ namespace Opc.Ua
             EndpointConfiguration endpointConfiguration,
             X509Certificate2 clientCertificate,
             X509Certificate2Collection clientCertificateChain,
-            ServiceMessageContext messageContext)
+            IServiceMessageContext messageContext)
         {
             // create a UA binary channel.
             ITransportChannel channel = CreateUaBinaryChannel(

--- a/Stack/Opc.Ua.Core/Stack/Client/UaChannelBase.cs
+++ b/Stack/Opc.Ua.Core/Stack/Client/UaChannelBase.cs
@@ -180,7 +180,7 @@ namespace Opc.Ua
         /// <summary>
         /// Gets the context used when serializing messages exchanged via the channel.
         /// </summary>
-        public ServiceMessageContext MessageContext
+        public IServiceMessageContext MessageContext
         {
             get
             {
@@ -688,7 +688,7 @@ namespace Opc.Ua
             EndpointConfiguration endpointConfiguration,
             X509Certificate2 clientCertificate,
             X509Certificate2Collection clientCertificateChain,
-            ServiceMessageContext messageContext)
+            IServiceMessageContext messageContext)
         {
             // initialize the channel which will be created with the server.
             string uriScheme = new Uri(description.EndpointUrl).Scheme;
@@ -741,7 +741,7 @@ namespace Opc.Ua
             EndpointDescription description,
             EndpointConfiguration endpointConfiguration,
             X509Certificate2 clientCertificate,
-            ServiceMessageContext messageContext)
+            IServiceMessageContext messageContext)
         {
             return CreateUaBinaryChannel(configuration, description, endpointConfiguration, clientCertificate, null, messageContext);
         }
@@ -762,7 +762,7 @@ namespace Opc.Ua
             EndpointConfiguration endpointConfiguration,
             X509Certificate2 clientCertificate,
             X509Certificate2Collection clientCertificateChain,
-            ServiceMessageContext messageContext)
+            IServiceMessageContext messageContext)
         {
             string uriScheme = new Uri(description.EndpointUrl).Scheme;
 

--- a/Stack/Opc.Ua.Core/Stack/Configuration/ApplicationConfiguration.cs
+++ b/Stack/Opc.Ua.Core/Stack/Configuration/ApplicationConfiguration.cs
@@ -196,7 +196,7 @@ namespace Opc.Ua
         /// </summary>
         /// <value>A new instance of a ServiceMessageContext object.</value>
         [Obsolete("Warning: Behavior changed return a copy instead of a reference. Should call CreateMessageContext() instead.")]
-        public ServiceMessageContext MessageContext
+        public IServiceMessageContext MessageContext
         {
             get
             {

--- a/Stack/Opc.Ua.Core/Stack/Constants/DataTypes.Helpers.cs
+++ b/Stack/Opc.Ua.Core/Stack/Constants/DataTypes.Helpers.cs
@@ -136,7 +136,7 @@ namespace Opc.Ua
         /// <summary>
         /// Returns the system type for the datatype.
         /// </summary>
-        public static Type GetSystemType(NodeId datatypeId, EncodeableFactory factory)
+        public static Type GetSystemType(NodeId datatypeId, IEncodeableFactory factory)
         {
             return TypeInfo.GetSystemType(datatypeId, factory);
         }

--- a/Stack/Opc.Ua.Core/Stack/Server/EndpointBase.cs
+++ b/Stack/Opc.Ua.Core/Stack/Server/EndpointBase.cs
@@ -443,7 +443,7 @@ namespace Opc.Ua
         /// Returns the message context used by the server associated with the endpoint.
         /// </summary>
         /// <value>The message context.</value>
-        protected ServiceMessageContext MessageContext
+        protected IServiceMessageContext MessageContext
         {
             get { return m_messageContext; }
             set { m_messageContext = value; }
@@ -852,7 +852,7 @@ namespace Opc.Ua
 
         #region Private Fields
         private ServiceResult m_serverError;
-        private ServiceMessageContext m_messageContext;
+        private IServiceMessageContext m_messageContext;
         private EndpointDescription m_endpointDescription;
         private Dictionary<ExpandedNodeId, ServiceDefinition> m_supportedServices;
         private IServiceHostBase m_host;

--- a/Stack/Opc.Ua.Core/Stack/Server/IServerBase.cs
+++ b/Stack/Opc.Ua.Core/Stack/Server/IServerBase.cs
@@ -23,7 +23,7 @@ namespace Opc.Ua
         /// <value>
         /// The context information associated with a UA server that is used during message processing.
         /// </value>
-        ServiceMessageContext MessageContext { get; }
+        IServiceMessageContext MessageContext { get; }
 
         /// <summary>
         /// An error condition that describes why the server if not running (null if no error exists).

--- a/Stack/Opc.Ua.Core/Stack/Server/ServerBase.cs
+++ b/Stack/Opc.Ua.Core/Stack/Server/ServerBase.cs
@@ -95,11 +95,11 @@ namespace Opc.Ua
         /// <value>The message context that stores context information associated with a UA 
         /// server that is used during message processing.
         /// </value>
-        public ServiceMessageContext MessageContext
+        public IServiceMessageContext MessageContext
         {
             get
             {
-                return (ServiceMessageContext)m_messageContext;
+                return (IServiceMessageContext)m_messageContext;
             }
 
             set
@@ -1258,7 +1258,9 @@ namespace Opc.Ua
             }
 
             // use the message context from the configuration to ensure the channels are using the same one.
-            MessageContext = configuration.CreateMessageContext();
+            ServiceMessageContext messageContext = configuration.CreateMessageContext();
+            messageContext.NamespaceUris = new NamespaceTable();
+            MessageContext = messageContext;
 
             // assign a unique identifier if none specified.
             if (String.IsNullOrEmpty(configuration.ApplicationUri))
@@ -1276,7 +1278,6 @@ namespace Opc.Ua
             }
 
             // initialize namespace table.
-            MessageContext.NamespaceUris = new NamespaceTable();
             MessageContext.NamespaceUris.Append(configuration.ApplicationUri);
 
             // assign an instance name.

--- a/Stack/Opc.Ua.Core/Stack/State/ISystemContext.cs
+++ b/Stack/Opc.Ua.Core/Stack/State/ISystemContext.cs
@@ -73,7 +73,7 @@ namespace Opc.Ua
         /// A factory that can be used to create encodeable types.
         /// </summary>
         /// <value>The encodeable factory.</value>
-        EncodeableFactory EncodeableFactory { get; }
+        IEncodeableFactory EncodeableFactory { get; }
 
         /// <summary>
         /// A factory that can be used to create node ids.
@@ -260,7 +260,7 @@ namespace Opc.Ua
         /// A factory that can be used to create encodeable types.
         /// </summary>
         /// <value>The encodeable factory.</value>
-        public EncodeableFactory EncodeableFactory
+        public IEncodeableFactory EncodeableFactory
         {
             get { return m_encodeableFactory; }
             set { m_encodeableFactory = value; }
@@ -397,7 +397,7 @@ namespace Opc.Ua
         private NamespaceTable m_namespaceUris;
         private StringTable m_serverUris;
         private ITypeTable m_typeTable;
-        private EncodeableFactory m_encodeableFactory;
+        private IEncodeableFactory m_encodeableFactory;
         private INodeIdFactory m_nodeIdFactory;
         private IOperationContext m_operationContext;
         private NodeStateFactory m_nodeStateFactory;

--- a/Stack/Opc.Ua.Core/Stack/Tcp/ChannelQuotas.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/ChannelQuotas.cs
@@ -35,7 +35,7 @@ namespace Opc.Ua.Bindings
         /// <summary>
         /// The context to use when encoding/decoding messages.
         /// </summary>
-        public ServiceMessageContext MessageContext
+        public IServiceMessageContext MessageContext
         {
             get
             {
@@ -171,7 +171,7 @@ namespace Opc.Ua.Bindings
         private int m_maxBufferSize;
         private int m_channelLifetime;
         private int m_securityTokenLifetime;
-        private ServiceMessageContext m_messageContext;
+        private IServiceMessageContext m_messageContext;
         private ICertificateValidator m_certificateValidator;
         #endregion
     }

--- a/Stack/Opc.Ua.Core/Stack/Tcp/TcpTransportListener.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/TcpTransportListener.cs
@@ -111,21 +111,24 @@ namespace Opc.Ua.Bindings
 
             // initialize the quotas.
             m_quotas = new ChannelQuotas();
-            m_quotas.MessageContext = new ServiceMessageContext();
+            var messageContext = new ServiceMessageContext() {
+                NamespaceUris = settings.NamespaceUris,
+                ServerUris = new StringTable(),
+                Factory = settings.Factory
+            };
+
             if (configuration != null)
             {
                 m_quotas.MaxBufferSize = configuration.MaxBufferSize;
                 m_quotas.MaxMessageSize = configuration.MaxMessageSize;
                 m_quotas.ChannelLifetime = configuration.ChannelLifetime;
                 m_quotas.SecurityTokenLifetime = configuration.SecurityTokenLifetime;
-                m_quotas.MessageContext.MaxArrayLength = configuration.MaxArrayLength;
-                m_quotas.MessageContext.MaxByteStringLength = configuration.MaxByteStringLength;
-                m_quotas.MessageContext.MaxMessageSize = configuration.MaxMessageSize;
-                m_quotas.MessageContext.MaxStringLength = configuration.MaxStringLength;
+                messageContext.MaxArrayLength = configuration.MaxArrayLength;
+                messageContext.MaxByteStringLength = configuration.MaxByteStringLength;
+                messageContext.MaxMessageSize = configuration.MaxMessageSize;
+                messageContext.MaxStringLength = configuration.MaxStringLength;
             }
-            m_quotas.MessageContext.NamespaceUris = settings.NamespaceUris;
-            m_quotas.MessageContext.ServerUris = new StringTable();
-            m_quotas.MessageContext.Factory = settings.Factory;
+            m_quotas.MessageContext = messageContext;
 
             m_quotas.CertificateValidator = settings.CertificateValidator;
 

--- a/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryTransportChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryTransportChannel.cs
@@ -88,7 +88,7 @@ namespace Opc.Ua.Bindings
         /// <summary>
         /// Gets the context used when serializing messages exchanged via the channel.
         /// </summary>
-        public ServiceMessageContext MessageContext => m_quotas.MessageContext;
+        public IServiceMessageContext MessageContext => m_quotas.MessageContext;
 
         /// <summary>
         ///  Gets the the channel's current security token.
@@ -403,15 +403,15 @@ namespace Opc.Ua.Bindings
             m_quotas.ChannelLifetime = m_settings.Configuration.ChannelLifetime;
             m_quotas.SecurityTokenLifetime = m_settings.Configuration.SecurityTokenLifetime;
 
-            m_quotas.MessageContext = new ServiceMessageContext();
-
-            m_quotas.MessageContext.MaxArrayLength = m_settings.Configuration.MaxArrayLength;
-            m_quotas.MessageContext.MaxByteStringLength = m_settings.Configuration.MaxByteStringLength;
-            m_quotas.MessageContext.MaxMessageSize = m_settings.Configuration.MaxMessageSize;
-            m_quotas.MessageContext.MaxStringLength = m_settings.Configuration.MaxStringLength;
-            m_quotas.MessageContext.NamespaceUris = m_settings.NamespaceUris;
-            m_quotas.MessageContext.ServerUris = new StringTable();
-            m_quotas.MessageContext.Factory = m_settings.Factory;
+            m_quotas.MessageContext = new ServiceMessageContext() {
+                MaxArrayLength = m_settings.Configuration.MaxArrayLength,
+                MaxByteStringLength = m_settings.Configuration.MaxByteStringLength,
+                MaxMessageSize = m_settings.Configuration.MaxMessageSize,
+                MaxStringLength = m_settings.Configuration.MaxStringLength,
+                NamespaceUris = m_settings.NamespaceUris,
+                ServerUris = new StringTable(),
+                Factory = m_settings.Factory
+            };
 
             m_quotas.CertificateValidator = settings.CertificateValidator;
 

--- a/Stack/Opc.Ua.Core/Stack/Transport/ITransportChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Transport/ITransportChannel.cs
@@ -40,7 +40,7 @@ namespace Opc.Ua
         /// <summary>
         /// Gets the context used when serializing messages exchanged via the channel.
         /// </summary>
-        ServiceMessageContext MessageContext { get; }
+        IServiceMessageContext MessageContext { get; }
 
         /// <summary>
         /// Gets the the channel's current security token.

--- a/Stack/Opc.Ua.Core/Stack/Transport/TransportChannelSettings.cs
+++ b/Stack/Opc.Ua.Core/Stack/Transport/TransportChannelSettings.cs
@@ -116,7 +116,7 @@ namespace Opc.Ua
         /// in the encoded message.
         /// </remarks>
         /// <seealso cref="NamespaceUris" />
-        public EncodeableFactory Factory
+        public IEncodeableFactory Factory
         {
             get { return m_channelFactory; }
             set { m_channelFactory = value; }
@@ -131,7 +131,7 @@ namespace Opc.Ua
         private X509Certificate2 m_serverCertificate;
         private ICertificateValidator m_certificateValidator;
         private NamespaceTable m_namespaceUris;
-        private EncodeableFactory m_channelFactory;
+        private IEncodeableFactory m_channelFactory;
         #endregion
     }
 }

--- a/Stack/Opc.Ua.Core/Stack/Transport/TransportListenerSettings.cs
+++ b/Stack/Opc.Ua.Core/Stack/Transport/TransportListenerSettings.cs
@@ -103,7 +103,7 @@ namespace Opc.Ua
         /// in the encoded message.
         /// </remarks>
         /// <seealso cref="NamespaceUris" />
-        public EncodeableFactory Factory
+        public IEncodeableFactory Factory
         {
             get { return m_channelFactory; }
             set { m_channelFactory = value; }
@@ -126,7 +126,7 @@ namespace Opc.Ua
         private X509Certificate2Collection m_serverCertificateChain;
         private ICertificateValidator m_certificateValidator;
         private NamespaceTable m_namespaceUris;
-        private EncodeableFactory m_channelFactory;
+        private IEncodeableFactory m_channelFactory;
         private bool m_reverseConnectListener;
         #endregion
     }

--- a/Stack/Opc.Ua.Core/Types/BuiltIn/ExtensionObject.cs
+++ b/Stack/Opc.Ua.Core/Types/BuiltIn/ExtensionObject.cs
@@ -799,7 +799,7 @@ namespace Opc.Ua
         private ExpandedNodeId m_typeId;
         private ExtensionObjectEncoding m_encoding;
         private object m_body;
-        private ServiceMessageContext m_context;
+        private IServiceMessageContext m_context;
         #endregion
     }
 

--- a/Stack/Opc.Ua.Core/Types/BuiltIn/MessageContextExtension.cs
+++ b/Stack/Opc.Ua.Core/Types/BuiltIn/MessageContextExtension.cs
@@ -21,9 +21,9 @@ namespace Opc.Ua
         /// <summary>
         /// Initializes the object with the message context to use.
         /// </summary>
-        public MessageContextExtension(ServiceMessageContext messageContext)
+        public MessageContextExtension(IServiceMessageContext messageContext)
         {
-            m_messageContext = messageContext;
+            MessageContext = messageContext;
         }
 
         /// <summary>
@@ -34,7 +34,7 @@ namespace Opc.Ua
         /// <summary>
         /// Returns the message context associated with the current operation context.
         /// </summary>
-        public static ServiceMessageContext CurrentContext
+        public static IServiceMessageContext CurrentContext
         {
             get
             {
@@ -52,9 +52,7 @@ namespace Opc.Ua
         /// <summary>
         /// The message context to use.
         /// </summary>
-        public ServiceMessageContext MessageContext => m_messageContext;
-
-        private ServiceMessageContext m_messageContext;
+        public IServiceMessageContext MessageContext { get; private set; }
     }
     #endregion
 }

--- a/Stack/Opc.Ua.Core/Types/Encoders/BinaryDecoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/BinaryDecoder.cs
@@ -26,7 +26,7 @@ namespace Opc.Ua
         /// <summary>
         /// Creates a decoder that reads from a memory buffer.
         /// </summary>
-        public BinaryDecoder(byte[] buffer, ServiceMessageContext context)
+        public BinaryDecoder(byte[] buffer, IServiceMessageContext context)
         :
             this(buffer, 0, buffer.Length, context)
         {
@@ -35,7 +35,7 @@ namespace Opc.Ua
         /// <summary>
         /// Creates a decoder that reads from a memory buffer.
         /// </summary>
-        public BinaryDecoder(byte[] buffer, int start, int count, ServiceMessageContext context)
+        public BinaryDecoder(byte[] buffer, int start, int count, IServiceMessageContext context)
         {
             m_istrm = new MemoryStream(buffer, start, count, false);
             m_reader = new BinaryReader(m_istrm);
@@ -46,7 +46,7 @@ namespace Opc.Ua
         /// <summary>
         /// Creates a decoder that reads from a stream.
         /// </summary>
-        public BinaryDecoder(Stream stream, ServiceMessageContext context)
+        public BinaryDecoder(Stream stream, IServiceMessageContext context)
         {
             if (stream == null) throw new ArgumentNullException(nameof(stream));
 
@@ -130,7 +130,7 @@ namespace Opc.Ua
         /// <summary>
         /// Decodes a message from a stream.
         /// </summary>
-        public static IEncodeable DecodeMessage(Stream stream, System.Type expectedType, ServiceMessageContext context)
+        public static IEncodeable DecodeMessage(Stream stream, System.Type expectedType, IServiceMessageContext context)
         {
             if (stream == null) throw new ArgumentNullException(nameof(stream));
             if (context == null) throw new ArgumentNullException(nameof(context));
@@ -150,7 +150,7 @@ namespace Opc.Ua
         /// <summary>
         /// Decodes a session-less message from a buffer.
         /// </summary>
-        public static IEncodeable DecodeSessionLessMessage(byte[] buffer, ServiceMessageContext context)
+        public static IEncodeable DecodeSessionLessMessage(byte[] buffer, IServiceMessageContext context)
         {
             if (buffer == null) throw new ArgumentNullException(nameof(buffer));
             if (context == null) throw new ArgumentNullException(nameof(context));
@@ -189,7 +189,7 @@ namespace Opc.Ua
         /// <summary>
         /// Decodes a message from a buffer.
         /// </summary>
-        public static IEncodeable DecodeMessage(byte[] buffer, System.Type expectedType, ServiceMessageContext context)
+        public static IEncodeable DecodeMessage(byte[] buffer, System.Type expectedType, IServiceMessageContext context)
         {
             if (buffer == null) throw new ArgumentNullException(nameof(buffer));
             if (context == null) throw new ArgumentNullException(nameof(context));
@@ -274,7 +274,7 @@ namespace Opc.Ua
         /// <summary>
         /// The message context associated with the decoder.
         /// </summary>
-        public ServiceMessageContext Context => m_context;
+        public IServiceMessageContext Context => m_context;
 
         /// <summary>
         /// Pushes a namespace onto the namespace stack.
@@ -2384,7 +2384,7 @@ namespace Opc.Ua
         #region Private Fields
         private Stream m_istrm;
         private BinaryReader m_reader;
-        private ServiceMessageContext m_context;
+        private IServiceMessageContext m_context;
         private ushort[] m_namespaceMappings;
         private ushort[] m_serverMappings;
         private uint m_nestingLevel;

--- a/Stack/Opc.Ua.Core/Types/Encoders/BinaryEncoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/BinaryEncoder.cs
@@ -28,7 +28,7 @@ namespace Opc.Ua
         /// <summary>
         /// Creates an encoder that writes to a memory buffer.
         /// </summary>
-        public BinaryEncoder(ServiceMessageContext context)
+        public BinaryEncoder(IServiceMessageContext context)
         {
             m_ostrm = new MemoryStream();
             m_writer = new BinaryWriter(m_ostrm);
@@ -39,7 +39,7 @@ namespace Opc.Ua
         /// <summary>
         /// Creates an encoder that writes to a fixed size memory buffer.
         /// </summary>
-        public BinaryEncoder(byte[] buffer, int start, int count, ServiceMessageContext context)
+        public BinaryEncoder(byte[] buffer, int start, int count, IServiceMessageContext context)
         {
             if (buffer == null) throw new ArgumentNullException(nameof(buffer));
 
@@ -52,7 +52,7 @@ namespace Opc.Ua
         /// <summary>
         /// Creates an encoder that writes to the stream.
         /// </summary>
-        public BinaryEncoder(Stream stream, ServiceMessageContext context)
+        public BinaryEncoder(Stream stream, IServiceMessageContext context)
         {
             if (stream == null) throw new ArgumentNullException(nameof(stream));
 
@@ -172,7 +172,7 @@ namespace Opc.Ua
         /// <summary>
         /// Encodes a message in a buffer.
         /// </summary>
-        public static byte[] EncodeMessage(IEncodeable message, ServiceMessageContext context)
+        public static byte[] EncodeMessage(IEncodeable message, IServiceMessageContext context)
         {
             if (message == null) throw new ArgumentNullException(nameof(message));
             if (context == null) throw new ArgumentNullException(nameof(context));
@@ -190,7 +190,7 @@ namespace Opc.Ua
         /// <summary>
         /// Encodes a session-less message to a buffer.
         /// </summary>
-        public static void EncodeSessionLessMessage(IEncodeable message, Stream stream, ServiceMessageContext context, bool leaveOpen = false)
+        public static void EncodeSessionLessMessage(IEncodeable message, Stream stream, IServiceMessageContext context, bool leaveOpen = false)
         {
             if (message == null) throw new ArgumentNullException(nameof(message));
             if (context == null) throw new ArgumentNullException(nameof(context));
@@ -236,7 +236,7 @@ namespace Opc.Ua
         /// <summary>
         /// Encodes a message in a stream.
         /// </summary>
-        public static void EncodeMessage(IEncodeable message, Stream stream, ServiceMessageContext context, bool leaveOpen = false)
+        public static void EncodeMessage(IEncodeable message, Stream stream, IServiceMessageContext context, bool leaveOpen = false)
         {
             if (message == null) throw new ArgumentNullException(nameof(message));
             if (stream == null) throw new ArgumentNullException(nameof(stream));
@@ -313,7 +313,7 @@ namespace Opc.Ua
         /// <summary>
         /// The message context associated with the encoder.
         /// </summary>
-        public ServiceMessageContext Context => m_context;
+        public IServiceMessageContext Context => m_context;
 
         /// <summary>
         /// Binary Encoder always produces reversible encoding.
@@ -2353,7 +2353,7 @@ namespace Opc.Ua
         #region Private Fields
         private Stream m_ostrm;
         private BinaryWriter m_writer;
-        private ServiceMessageContext m_context;
+        private IServiceMessageContext m_context;
         private ushort[] m_namespaceMappings;
         private ushort[] m_serverMappings;
         private uint m_nestingLevel;

--- a/Stack/Opc.Ua.Core/Types/Encoders/EncodableObject.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/EncodableObject.cs
@@ -52,7 +52,7 @@ namespace Opc.Ua
         /// <summary>
         /// Applies the data encoding to the value.
         /// </summary>
-        public static ServiceResult ApplyDataEncoding(ServiceMessageContext context, QualifiedName dataEncoding, ref object value)
+        public static ServiceResult ApplyDataEncoding(IServiceMessageContext context, QualifiedName dataEncoding, ref object value)
         {
             // check if nothing to do.
             if (QualifiedName.IsNull(dataEncoding) || value == null)
@@ -155,7 +155,7 @@ namespace Opc.Ua
         /// <summary>
         /// Encodes the object in XML or Binary
         /// </summary>
-        public static ExtensionObject Encode(ServiceMessageContext context, IEncodeable encodeable, bool useXml)
+        public static ExtensionObject Encode(IServiceMessageContext context, IEncodeable encodeable, bool useXml)
         {
             if (useXml)
             {
@@ -172,7 +172,7 @@ namespace Opc.Ua
         /// <summary>
         /// Encodes the object in XML.
         /// </summary>
-        public static XmlElement EncodeXml(IEncodeable encodeable, ServiceMessageContext context)
+        public static XmlElement EncodeXml(IEncodeable encodeable, IServiceMessageContext context)
         {
             // create encoder.
             XmlEncoder encoder = new XmlEncoder(context);
@@ -191,7 +191,7 @@ namespace Opc.Ua
         /// <summary>
         /// Encodes the object in binary
         /// </summary>
-        public static byte[] EncodeBinary(IEncodeable encodeable, ServiceMessageContext context)
+        public static byte[] EncodeBinary(IEncodeable encodeable, IServiceMessageContext context)
         {
             BinaryEncoder encoder = new BinaryEncoder(context);
             encoder.WriteEncodeable(null, encodeable, null);

--- a/Stack/Opc.Ua.Core/Types/Encoders/EncodeableFactory.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/EncodeableFactory.cs
@@ -21,9 +21,9 @@ using System.Threading;
 namespace Opc.Ua
 {
 
-	/// <summary>
-	/// Creates encodeable objects based on the type id.
-	/// </summary>
+    /// <summary>
+    /// Creates encodeable objects based on the type id.
+    /// </summary>
     /// <remarks>
     /// <para>
     /// This factory is used to store and retrieve underlying OPC UA system types.
@@ -33,55 +33,55 @@ namespace Opc.Ua
     /// Once the types exist within the factory, these types can be then easily queried.
     /// <br/></para>
     /// </remarks>
-	public class EncodeableFactory
-	{	
-		#region Constructors
-		/// <summary>
-		/// Creates a factory initialized with the types in the core library.
-		/// </summary>
-		public EncodeableFactory()
+    public class EncodeableFactory : IEncodeableFactory
+    {
+        #region Constructors
+        /// <summary>
+        /// Creates a factory initialized with the types in the core library.
+        /// </summary>
+        public EncodeableFactory()
         {
             m_encodeableTypes = new Dictionary<ExpandedNodeId, System.Type>();
             AddEncodeableTypes(this.GetType().GetTypeInfo().Assembly);
 
-            #if DEBUG
+#if DEBUG
             m_instanceId = Interlocked.Increment(ref m_globalInstanceCount);
-            #endif
-		}
+#endif
+        }
 
-		/// <summary>
-		/// Creates a factory which is marked as shared and initialized with the types in the core library.
-		/// </summary>
-		public EncodeableFactory(bool shared)
+        /// <summary>
+        /// Creates a factory which is marked as shared and initialized with the types in the core library.
+        /// </summary>
+        public EncodeableFactory(bool shared)
         {
             m_encodeableTypes = new Dictionary<ExpandedNodeId, System.Type>();
             AddEncodeableTypes(Utils.DefaultOpcUaCoreAssemblyFullName);
 
-            #if DEBUG
+#if DEBUG
             m_instanceId = Interlocked.Increment(ref m_globalInstanceCount);
             m_shared = true;
-            #endif
-		}
+#endif
+        }
 
-		/// <summary>
-		/// Creates a factory by copying the table from another factory.
-		/// </summary>
-		public EncodeableFactory(EncodeableFactory factory)
+        /// <summary>
+        /// Creates a factory by copying the table from another factory.
+        /// </summary>
+        public EncodeableFactory(IEncodeableFactory factory)
         {
             m_encodeableTypes = new Dictionary<ExpandedNodeId, System.Type>();
 
-            #if DEBUG
+#if DEBUG
             m_instanceId = Interlocked.Increment(ref m_globalInstanceCount);
-            #endif
+#endif
 
-            lock (factory.m_lock)
+            lock (factory.SyncRoot)
             {
-                foreach (KeyValuePair<ExpandedNodeId,System.Type> current in factory.m_encodeableTypes)
+                foreach (KeyValuePair<ExpandedNodeId, System.Type> current in factory.EncodeableTypes)
                 {
                     m_encodeableTypes.Add(current.Key, current.Value);
                 }
             }
-		}
+        }
 
         /// <summary>
         /// Loads the types from an assembly.
@@ -99,9 +99,9 @@ namespace Opc.Ua
                 Utils.Trace("Could not load encodeable types from assembly: {0}", assemblyName);
             }
         }
-		#endregion
+        #endregion
 
-		#region Static Members
+        #region Static Members
         /// <summary>
         /// The default factory for the process.
         /// </summary>
@@ -112,23 +112,23 @@ namespace Opc.Ua
         {
             get { return s_globalFactory; }
         }
-                
-		/// <summary>
-		/// Returns the xml qualified name for the specified system type id.
-		/// </summary>
+
+        /// <summary>
+        /// Returns the xml qualified name for the specified system type id.
+        /// </summary>
         /// <remarks>
         /// Returns the xml qualified name for the specified system type id.
         /// </remarks>
         /// <param name="systemType">The underlying type to query and return the Xml qualified name of</param>
         public static XmlQualifiedName GetXmlName(System.Type systemType)
-		{
+        {
             if (systemType == null)
             {
                 return null;
             }
 
             object[] attributes = systemType.GetTypeInfo().GetCustomAttributes(typeof(DataContractAttribute), true).ToArray();
-            
+
             if (attributes != null)
             {
                 for (int ii = 0; ii < attributes.Length; ii++)
@@ -141,14 +141,14 @@ namespace Opc.Ua
                         {
                             return new XmlQualifiedName(systemType.Name, contract.Namespace);
                         }
-                         
+
                         return new XmlQualifiedName(contract.Name, contract.Namespace);
                     }
-                }                            
+                }
             }
 
             attributes = systemType.GetTypeInfo().GetCustomAttributes(typeof(CollectionDataContractAttribute), true).ToArray();
-            
+
             if (attributes != null)
             {
                 for (int ii = 0; ii < attributes.Length; ii++)
@@ -161,10 +161,10 @@ namespace Opc.Ua
                         {
                             return new XmlQualifiedName(systemType.Name, contract.Namespace);
                         }
-                         
+
                         return new XmlQualifiedName(contract.Name, contract.Namespace);
                     }
-                }                            
+                }
             }
 
             if (systemType == typeof(System.Byte[]))
@@ -173,31 +173,31 @@ namespace Opc.Ua
             }
 
             return new XmlQualifiedName(systemType.FullName);
-		}
-		#endregion
+        }
+        #endregion
 
-		#region Public Members
-		/// <summary>
-		/// Returns the object used to synchronize access to the factory.
-		/// </summary>
+        #region Public Members
+        /// <summary>
+        /// Returns the object used to synchronize access to the factory.
+        /// </summary>
         /// <remarks>
         /// Returns the object used to synchronize access to the factory.
         /// </remarks>
-		public object SyncRoot
-		{
-			get { return m_lock; }
-		}
+        public object SyncRoot
+        {
+            get { return m_lock; }
+        }
 
         /// <summary>
         /// Returns a unique identifier for the table instance. Used to debug problems with shared tables.
         /// </summary>
         public int InstanceId
         {
-            #if DEBUG
+#if DEBUG
             get { return m_instanceId; }
-            #else
+#else
             get { return 0; }
-            #endif
+#endif
         }
 
         /// <summary>
@@ -227,16 +227,16 @@ namespace Opc.Ua
                 {
                     return;
                 }
-                
-                #if DEBUG
+
+#if DEBUG
                 if (m_shared)
                 {
                     Utils.Trace("WARNING: Adding type '{0}' to shared Factory #{1}.", systemType.Name, m_instanceId);
                 }
-                #endif
-                
+#endif
+
                 ExpandedNodeId nodeId = encodeable.TypeId;
-                        
+
                 if (!NodeId.IsNull(nodeId))
                 {
                     // check for default namespace.
@@ -249,7 +249,7 @@ namespace Opc.Ua
                 }
 
                 nodeId = encodeable.BinaryEncodingId;
-                        
+
                 if (!NodeId.IsNull(nodeId))
                 {
                     // check for default namespace.
@@ -262,7 +262,7 @@ namespace Opc.Ua
                 }
 
                 nodeId = encodeable.XmlEncodingId;
-                
+
                 if (!NodeId.IsNull(nodeId))
                 {
                     // check for default namespace.
@@ -287,18 +287,18 @@ namespace Opc.Ua
             {
                 if (systemType != null && !NodeId.IsNull(encodingId))
                 {
-                    #if DEBUG
+#if DEBUG
                     if (m_shared)
                     {
                         Utils.Trace("WARNING: Adding type '{0}' to shared Factory #{1}.", systemType.Name, m_instanceId);
                     }
-                    #endif
+#endif
 
                     m_encodeableTypes[encodingId] = systemType;
                 }
             }
         }
-               
+
         /// <summary>
         /// Adds all encodable types exported from an assembly to the factory.
         /// </summary>
@@ -317,12 +317,12 @@ namespace Opc.Ua
         {
             if (assembly != null)
             {
-                #if DEBUG
+#if DEBUG
                 if (m_shared)
                 {
                     Utils.Trace("WARNING: Adding types from assembly '{0}' to shared Factory #{1}.", assembly.FullName, m_instanceId);
                 }
-                #endif
+#endif
 
                 lock (m_lock)
                 {
@@ -340,19 +340,19 @@ namespace Opc.Ua
                 }
             }
         }
-        
-		/// <summary>
-		/// Returns the system type for the specified type id.
-		/// </summary>
+
+        /// <summary>
+        /// Returns the system type for the specified type id.
+        /// </summary>
         /// <remarks>
         /// Returns the system type for the specified type id.
         /// </remarks>
         /// <param name="typeId">The type id to return the system-type of</param>
         public System.Type GetSystemType(ExpandedNodeId typeId)
-		{
-			lock (m_lock)
-			{
-                System.Type systemType = null; 
+        {
+            lock (m_lock)
+            {
+                System.Type systemType = null;
 
                 if (NodeId.IsNull(typeId) || !m_encodeableTypes.TryGetValue(typeId, out systemType))
                 {
@@ -360,22 +360,27 @@ namespace Opc.Ua
                 }
 
                 return systemType;
-			}
-		}
+            }
+        }
+
+        /// <summary>
+        /// The dictionary of encodeabe types.
+        /// </summary>
+        public IReadOnlyDictionary<ExpandedNodeId, Type> EncodeableTypes => m_encodeableTypes;
         #endregion
 
-		#region Private Fields
-		private object m_lock = new object();
-		private Dictionary<ExpandedNodeId,System.Type> m_encodeableTypes;
+        #region Private Fields
+        private object m_lock = new object();
+        private Dictionary<ExpandedNodeId, Type> m_encodeableTypes;
         private static EncodeableFactory s_globalFactory = new EncodeableFactory();
 
-        #if DEBUG
+#if DEBUG
         private bool m_shared;
         private int m_instanceId;
         private static int m_globalInstanceCount;
-        #endif
-		#endregion
+#endif
+        #endregion
 
-	}//class
+    }//class
 
 }//namespace

--- a/Stack/Opc.Ua.Core/Types/Encoders/IDecoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/IDecoder.cs
@@ -28,7 +28,7 @@ namespace Opc.Ua
         /// <summary>
         /// The message context associated with the decoder.
         /// </summary>
-        ServiceMessageContext Context { get; }
+        IServiceMessageContext Context { get; }
 
         /// <summary>
         /// Initializes the tables used to map namespace and server uris during decoding.

--- a/Stack/Opc.Ua.Core/Types/Encoders/IEncodeableFactory.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/IEncodeableFactory.cs
@@ -1,0 +1,92 @@
+/* Copyright (c) 1996-2020 The OPC Foundation. All rights reserved.
+   The source code in this file is covered under a dual-license scenario:
+     - RCL: for OPC Foundation members in good-standing
+     - GPL V2: everybody else
+   RCL license terms accompanied with this source code. See http://opcfoundation.org/License/RCL/1.00/
+   GNU General Public License as published by the Free Software Foundation;
+   version 2 of the License are accompanied with this source code. See http://opcfoundation.org/License/GPLv2
+   This source code is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Opc.Ua
+{
+    /// <summary>
+    /// Creates encodeable objects based on the type id.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This factory is used to store and retrieve underlying OPC UA system types.
+    /// <br/></para>
+    /// <para>
+    /// You can manually add types. You can also import all types from a specified assembly.
+    /// Once the types exist within the factory, these types can be then easily queried.
+    /// <br/></para>
+    /// </remarks>
+    public interface IEncodeableFactory
+    {
+        /// <summary>
+        /// Returns the object used to synchronize access to the factory.
+        /// </summary>
+        /// <remarks>
+        /// Returns the object used to synchronize access to the factory.
+        /// </remarks>
+        object SyncRoot { get; }
+
+        /// <summary>
+        /// Returns a unique identifier for the table instance. Used to debug problems with shared tables.
+        /// </summary>
+        int InstanceId { get; }
+
+        /// <summary>
+        /// Adds an extension type to the factory.
+        /// </summary>
+        /// <remarks>
+        /// Adds an extension type to the factory.
+        /// </remarks>
+        /// <param name="systemType">The underlying system type to add to the factory</param>
+        void AddEncodeableType(Type systemType);
+
+        /// <summary>
+        /// Associates an encodeable type with an encoding id.
+        /// </summary>
+        /// <param name="encodingId">A NodeId for a Data Type Encoding node</param>
+        /// <param name="systemType">The system type to use for the specified encoding.</param>
+        void AddEncodeableType(ExpandedNodeId encodingId, Type systemType);
+
+        /// <summary>
+        /// Adds all encodable types exported from an assembly to the factory.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Adds all encodable types exported from an assembly to the factory.
+        /// <br/></para>
+        /// <para>
+        /// This method uses reflection on the specified assembly to export all of the
+        /// types the assembly exposes, and automatically adds all types that implement
+        /// the <see cref="IEncodeable"/> interface, to the factory.
+        /// <br/></para>
+        /// </remarks>
+        /// <param name="assembly">The assembly containing the types to add to the factory</param>
+        void AddEncodeableTypes(Assembly assembly);
+
+        /// <summary>
+        /// Returns the system type for the specified type id.
+        /// </summary>
+        /// <remarks>
+        /// Returns the system type for the specified type id.
+        /// </remarks>
+        /// <param name="typeId">The type id to return the system-type of</param>
+        Type GetSystemType(ExpandedNodeId typeId);
+
+        /// <summary>
+        /// The dictionary of encodeable types.
+        /// </summary>
+        IReadOnlyDictionary<ExpandedNodeId, Type> EncodeableTypes { get; }
+    }
+}

--- a/Stack/Opc.Ua.Core/Types/Encoders/IEncoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/IEncoder.cs
@@ -34,7 +34,7 @@ namespace Opc.Ua
         /// <summary>
         /// The message context associated with the encoder.
         /// </summary>
-        ServiceMessageContext Context { get; }
+        IServiceMessageContext Context { get; }
 
         /// <summary>
         /// Sets the mapping tables to use during decoding.

--- a/Stack/Opc.Ua.Core/Types/Encoders/JsonDecoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/JsonDecoder.cs
@@ -34,11 +34,10 @@ namespace Opc.Ua
         #endregion
 
         #region Private Fields
-
         private JsonTextReader m_reader;
         private Dictionary<string, object> m_root;
         private Stack<object> m_stack;
-        private ServiceMessageContext m_context;
+        private IServiceMessageContext m_context;
         private ushort[] m_namespaceMappings;
         private ushort[] m_serverMappings;
         private uint m_nestingLevel;
@@ -58,7 +57,7 @@ namespace Opc.Ua
         /// </summary>
         /// <param name="json">The JSON encoded string.</param>
         /// <param name="context">The service message context to use.</param>
-        public JsonDecoder(string json, ServiceMessageContext context)
+        public JsonDecoder(string json, IServiceMessageContext context)
         {
             if (context == null)
             {
@@ -80,7 +79,7 @@ namespace Opc.Ua
         /// <param name="systemType">The system type of the encoded JSON stram.</param>
         /// <param name="reader">The text reader.</param>
         /// <param name="context">The service message context to use.</param>
-        public JsonDecoder(Type systemType, JsonTextReader reader, ServiceMessageContext context)
+        public JsonDecoder(Type systemType, JsonTextReader reader, IServiceMessageContext context)
         {
             Initialize();
 
@@ -105,7 +104,7 @@ namespace Opc.Ua
         /// <summary>
         /// Decodes a session-less message from a buffer.
         /// </summary>
-        public static IEncodeable DecodeSessionLessMessage(byte[] buffer, ServiceMessageContext context)
+        public static IEncodeable DecodeSessionLessMessage(byte[] buffer, IServiceMessageContext context)
         {
             if (buffer == null) throw new ArgumentNullException(nameof(buffer));
             if (context == null) throw new ArgumentNullException(nameof(context));
@@ -128,7 +127,7 @@ namespace Opc.Ua
         /// <summary>
         /// Decodes a message from a buffer.
         /// </summary>
-        public static IEncodeable DecodeMessage(byte[] buffer, System.Type expectedType, ServiceMessageContext context)
+        public static IEncodeable DecodeMessage(byte[] buffer, System.Type expectedType, IServiceMessageContext context)
         {
             return DecodeMessage(new ArraySegment<byte>(buffer), expectedType, context);
         }
@@ -136,7 +135,7 @@ namespace Opc.Ua
         /// <summary>
         /// Decodes a message from a buffer.
         /// </summary>
-        public static IEncodeable DecodeMessage(ArraySegment<byte> buffer, System.Type expectedType, ServiceMessageContext context)
+        public static IEncodeable DecodeMessage(ArraySegment<byte> buffer, System.Type expectedType, IServiceMessageContext context)
         {
             if (context == null)
             {
@@ -290,7 +289,7 @@ namespace Opc.Ua
         /// <summary>
         /// The message context associated with the decoder.
         /// </summary>
-        public ServiceMessageContext Context => m_context;
+        public IServiceMessageContext Context => m_context;
 
         /// <summary>
         /// Pushes a namespace onto the namespace stack.

--- a/Stack/Opc.Ua.Core/Types/Encoders/JsonEncoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/JsonEncoder.cs
@@ -30,7 +30,7 @@ namespace Opc.Ua
         private Stack<string> m_namespaces;
         private bool m_commaRequired;
         private bool m_inVariantWithEncoding;
-        private ServiceMessageContext m_context;
+        private IServiceMessageContext m_context;
         private ushort[] m_namespaceMappings;
         private ushort[] m_serverMappings;
         private uint m_nestingLevel;
@@ -44,7 +44,7 @@ namespace Opc.Ua
         /// Initializes the object with default values.
         /// </summary>
         public JsonEncoder(
-            ServiceMessageContext context,
+            IServiceMessageContext context,
             bool useReversibleEncoding,
             StreamWriter writer = null,
             bool topLevelIsArray = false)
@@ -106,7 +106,7 @@ namespace Opc.Ua
         /// <summary>
         /// Encodes a session-less message to a buffer.
         /// </summary>
-        public static void EncodeSessionLessMessage(IEncodeable message, Stream stream, ServiceMessageContext context, bool leaveOpen = false)
+        public static void EncodeSessionLessMessage(IEncodeable message, Stream stream, IServiceMessageContext context, bool leaveOpen = false)
         {
             if (message == null) throw new ArgumentNullException(nameof(message));
             if (context == null) throw new ArgumentNullException(nameof(context));
@@ -152,7 +152,7 @@ namespace Opc.Ua
         /// <summary>
         /// Encodes a message in a stream.
         /// </summary>
-        public static ArraySegment<byte> EncodeMessage(IEncodeable message, byte[] buffer, ServiceMessageContext context)
+        public static ArraySegment<byte> EncodeMessage(IEncodeable message, byte[] buffer, IServiceMessageContext context)
         {
             if (message == null) throw new ArgumentNullException(nameof(message));
             if (buffer == null) throw new ArgumentNullException(nameof(buffer));
@@ -280,7 +280,7 @@ namespace Opc.Ua
         /// <summary>
         /// The message context associated with the encoder.
         /// </summary>
-        public ServiceMessageContext Context => m_context;
+        public IServiceMessageContext Context => m_context;
 
         /// <summary>
         /// The Json encoder reversible encoding option

--- a/Stack/Opc.Ua.Core/Types/Encoders/XmlDecoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/XmlDecoder.cs
@@ -28,7 +28,7 @@ namespace Opc.Ua
         /// <summary>
         /// Initializes the object with default values.
         /// </summary>
-        public XmlDecoder(ServiceMessageContext context)
+        public XmlDecoder(IServiceMessageContext context)
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
             Initialize();
@@ -39,7 +39,7 @@ namespace Opc.Ua
         /// <summary>
         /// Initializes the object with an XML element to parse.
         /// </summary>
-        public XmlDecoder(XmlElement element, ServiceMessageContext context)
+        public XmlDecoder(XmlElement element, IServiceMessageContext context)
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
             Initialize();
@@ -51,7 +51,7 @@ namespace Opc.Ua
         /// <summary>
         /// Initializes the object with a XML reader.
         /// </summary>
-        public XmlDecoder(System.Type systemType, XmlReader reader, ServiceMessageContext context)
+        public XmlDecoder(System.Type systemType, XmlReader reader, IServiceMessageContext context)
         {
             Initialize();
 
@@ -605,7 +605,7 @@ namespace Opc.Ua
         /// <summary>
         /// The message context associated with the decoder.
         /// </summary>
-        public ServiceMessageContext Context => m_context;
+        public IServiceMessageContext Context => m_context;
 
         /// <summary>
         /// Pushes a namespace onto the namespace stack.
@@ -3075,7 +3075,7 @@ namespace Opc.Ua
         #region Private Fields
         private XmlReader m_reader;
         private Stack<string> m_namespaces;
-        private ServiceMessageContext m_context;
+        private IServiceMessageContext m_context;
         private ushort[] m_namespaceMappings;
         private ushort[] m_serverMappings;
         private uint m_nestingLevel;

--- a/Stack/Opc.Ua.Core/Types/Encoders/XmlEncoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/XmlEncoder.cs
@@ -28,7 +28,7 @@ namespace Opc.Ua
         /// <summary>
         /// Initializes the object with default values.
         /// </summary>
-        public XmlEncoder(ServiceMessageContext context)
+        public XmlEncoder(IServiceMessageContext context)
         {
             Initialize();
 
@@ -48,7 +48,7 @@ namespace Opc.Ua
         /// <summary>
         /// Initializes the object with a system type to encode and a XML writer.
         /// </summary>
-        public XmlEncoder(System.Type systemType, XmlWriter writer, ServiceMessageContext context)
+        public XmlEncoder(System.Type systemType, XmlWriter writer, IServiceMessageContext context)
         :
             this(EncodeableFactory.GetXmlName(systemType), writer, context)
         {
@@ -57,7 +57,7 @@ namespace Opc.Ua
         /// <summary>
         /// Initializes the object with a system type to encode and a XML writer.
         /// </summary>
-        public XmlEncoder(XmlQualifiedName root, XmlWriter writer, ServiceMessageContext context)
+        public XmlEncoder(XmlQualifiedName root, XmlWriter writer, IServiceMessageContext context)
         {
             Initialize();
 
@@ -261,7 +261,7 @@ namespace Opc.Ua
         /// <summary>
         /// The message context associated with the encoder.
         /// </summary>
-        public ServiceMessageContext Context => m_context;
+        public IServiceMessageContext Context => m_context;
 
         /// <summary>
         /// Xml Encoder always produces reversible encoding.
@@ -2203,7 +2203,7 @@ namespace Opc.Ua
         private XmlWriter m_writer;
         private Stack<string> m_namespaces;
         private XmlQualifiedName m_root;
-        private ServiceMessageContext m_context;
+        private IServiceMessageContext m_context;
         private ushort[] m_namespaceMappings;
         private ushort[] m_serverMappings;
         private uint m_nestingLevel;

--- a/Stack/Opc.Ua.Core/Types/Utils/DataComparer.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/DataComparer.cs
@@ -909,7 +909,7 @@ namespace Opc.Ua.Test
         /// <summary>
         /// The factory to use when decoding extension objects.
         /// </summary>        
-        public static EncodeableFactory EncodeableFactory
+        public static IEncodeableFactory EncodeableFactory
         {
             get
             {
@@ -924,7 +924,7 @@ namespace Opc.Ua.Test
         }
 
         // It stores encodable types of the executing assembly.       
-        private static EncodeableFactory s_Factory = new EncodeableFactory();
+        private static IEncodeableFactory s_Factory = new EncodeableFactory();
 
         /// <summary>
         /// Extracts the extension object body.
@@ -957,7 +957,7 @@ namespace Opc.Ua.Test
 
             if (xml != null)
             {
-                XmlQualifiedName xmlName = EncodeableFactory.GetXmlName(expectedType);
+                XmlQualifiedName xmlName = Opc.Ua.EncodeableFactory.GetXmlName(expectedType);
                 XmlDecoder decoder = new XmlDecoder(xml, context);
 
                 decoder.PushNamespace(xmlName.Namespace);

--- a/Stack/Opc.Ua.Core/Types/Utils/DataComparer.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/DataComparer.cs
@@ -26,7 +26,7 @@ namespace Opc.Ua.Test
         /// <summary>
         /// Constructs an instance of the data comparer.
         /// </summary>
-        public DataComparer(ServiceMessageContext context)
+        public DataComparer(IServiceMessageContext context)
         {
             m_context = context;
             m_throwOnError = true;
@@ -949,8 +949,9 @@ namespace Opc.Ua.Test
                 return body;
             }
 
-            ServiceMessageContext context = new ServiceMessageContext();
-            context.Factory = EncodeableFactory;
+            IServiceMessageContext context = new ServiceMessageContext() {
+                Factory = EncodeableFactory
+            };
 
             XmlElement xml = body as XmlElement;
 
@@ -1168,7 +1169,7 @@ namespace Opc.Ua.Test
         #endregion
 
         #region Private Fields
-        private ServiceMessageContext m_context;
+        private IServiceMessageContext m_context;
         private bool m_throwOnError;
         #endregion
     }

--- a/Stack/Opc.Ua.Core/Types/Utils/IServiceMessageContext.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/IServiceMessageContext.cs
@@ -63,7 +63,7 @@ namespace Opc.Ua
         /// <summary>
         /// The factory used to create encodeable objects.
         /// </summary>
-        EncodeableFactory Factory { get; }
+        IEncodeableFactory Factory { get; }
         #endregion
     }
 }

--- a/Stack/Opc.Ua.Core/Types/Utils/IServiceMessageContext.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/IServiceMessageContext.cs
@@ -1,0 +1,69 @@
+/* Copyright (c) 1996-2020 The OPC Foundation. All rights reserved.
+   The source code in this file is covered under a dual-license scenario:
+     - RCL: for OPC Foundation members in good-standing
+     - GPL V2: everybody else
+   RCL license terms accompanied with this source code. See http://opcfoundation.org/License/RCL/1.00/
+   GNU General Public License as published by the Free Software Foundation;
+   version 2 of the License are accompanied with this source code. See http://opcfoundation.org/License/GPLv2
+   This source code is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+*/
+
+using System;
+
+namespace Opc.Ua
+{
+    /// <summary>
+	/// Stores context information for message encoding and decoding.
+	/// </summary>
+	public interface IServiceMessageContext
+    {
+        #region Public Properties
+        /// <summary>
+        /// Returns the object used to synchronize access to the context.
+        /// </summary>
+        object SyncRoot { get; }
+
+        /// <summary>
+        /// The maximum length for any string, byte string or xml element.
+        /// </summary>
+        int MaxStringLength { get; }
+
+        /// <summary>
+        /// The maximum length for any array.
+        /// </summary>
+        int MaxArrayLength { get; }
+
+        /// <summary>
+        /// The maximum length for any ByteString.
+        /// </summary>
+        int MaxByteStringLength { get; }
+
+        /// <summary>
+        /// The maximum length for any Message.
+        /// </summary>
+        int MaxMessageSize { get; }
+
+        /// <summary>
+        /// The maximum nesting level accepted while encoding or decoding objects.
+        /// </summary>
+        uint MaxEncodingNestingLevels { get; }
+
+        /// <summary>
+        /// The table of namespaces used by the server.
+        /// </summary>
+        NamespaceTable NamespaceUris { get; }
+
+        /// <summary>
+        /// The table of servers used by the server.
+        /// </summary>
+        StringTable ServerUris { get; }
+
+        /// <summary>
+        /// The factory used to create encodeable objects.
+        /// </summary>
+        EncodeableFactory Factory { get; }
+        #endregion
+    }
+}

--- a/Stack/Opc.Ua.Core/Types/Utils/ServiceMessageContext.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/ServiceMessageContext.cs
@@ -174,7 +174,7 @@ namespace Opc.Ua
         /// <summary>
         /// The factory used to create encodeable objects.
         /// </summary>
-        public EncodeableFactory Factory
+        public IEncodeableFactory Factory
         {
             get
             {
@@ -206,7 +206,7 @@ namespace Opc.Ua
         private uint m_maxEncodingNestingLevels;
         private NamespaceTable m_namespaceUris;
         private StringTable m_serverUris;
-        private EncodeableFactory m_factory;
+        private IEncodeableFactory m_factory;
 
         private static ServiceMessageContext s_globalContext = new ServiceMessageContext(true);
         #endregion

--- a/Stack/Opc.Ua.Core/Types/Utils/ServiceMessageContext.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/ServiceMessageContext.cs
@@ -17,7 +17,7 @@ namespace Opc.Ua
     /// <summary>
 	/// Stores context information associated with a UA server that is used during message processing.
 	/// </summary>
-	public class ServiceMessageContext
+	public class ServiceMessageContext : IServiceMessageContext
     {
         #region Constructors
         /// <summary>

--- a/Stack/Opc.Ua.Core/Types/Utils/TypeInfo.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/TypeInfo.cs
@@ -478,7 +478,7 @@ namespace Opc.Ua
         /// <param name="datatypeId">The datatype id.</param>
         /// <param name="factory">The factory used to store and retrieve underlying OPC UA system types.</param>
         /// <returns>The system type for the <paramref name="datatypeId"/>.</returns>
-        public static Type GetSystemType(ExpandedNodeId datatypeId, EncodeableFactory factory)
+        public static Type GetSystemType(ExpandedNodeId datatypeId, IEncodeableFactory factory)
         {
             if (datatypeId == null)
             {

--- a/Tests/Opc.Ua.Client.ComplexTypes.Tests/Types/ComplexTypesCommon.cs
+++ b/Tests/Opc.Ua.Client.ComplexTypes.Tests/Types/ComplexTypesCommon.cs
@@ -136,7 +136,7 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
         /// Builds a complex type with all BuiltInTypes as properties.
         /// </summary>
         public Type BuildComplexTypeWithAllBuiltInTypes(
-            ServiceMessageContext context,
+            IServiceMessageContext context,
             StructureType structureType,
             string testFunc,
             out ExpandedNodeId nodeId)
@@ -211,7 +211,7 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
         /// Create array of types for tests.
         /// </summary>
         public void CreateComplexTypes(
-            ServiceMessageContext context,
+            IServiceMessageContext context,
             Dictionary<StructureType, (ExpandedNodeId, Type)> dict,
             string nameExtension)
         {
@@ -270,7 +270,7 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
         /// Encode and decode a complex type, verify the result against expected data.
         /// </summary>
         protected void EncodeDecodeComplexType(
-            ServiceMessageContext encoderContext,
+            IServiceMessageContext encoderContext,
             EncodingType encoderType,
             StructureType structureType,
             ExpandedNodeId nodeId,

--- a/Tests/Opc.Ua.Client.ComplexTypes.Tests/Types/EncoderTests.cs
+++ b/Tests/Opc.Ua.Client.ComplexTypes.Tests/Types/EncoderTests.cs
@@ -50,9 +50,10 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
         [OneTimeSetUp]
         protected new void OneTimeSetUp()
         {
-            EncoderContext = new ServiceMessageContext();
-            // create private copy of factory
-            EncoderContext.Factory = new EncodeableFactory(EncoderContext.Factory);
+            EncoderContext = new ServiceMessageContext() {
+                // create private copy of factory
+                Factory = new EncodeableFactory(EncoderContext.Factory)
+            };
             // add a few random namespaces
             EncoderContext.NamespaceUris.Append("urn:This:is:my:test:encoder");
             EncoderContext.NamespaceUris.Append("urn:This:is:another:namespace");

--- a/Tests/Opc.Ua.Client.ComplexTypes.Tests/Types/EncoderTests.cs
+++ b/Tests/Opc.Ua.Client.ComplexTypes.Tests/Types/EncoderTests.cs
@@ -52,7 +52,7 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
         {
             EncoderContext = new ServiceMessageContext() {
                 // create private copy of factory
-                Factory = new EncodeableFactory(EncoderContext.Factory)
+                Factory = new EncodeableFactory(ServiceMessageContext.GlobalContext.Factory)
             };
             // add a few random namespaces
             EncoderContext.NamespaceUris.Append("urn:This:is:my:test:encoder");

--- a/Tests/Opc.Ua.Client.ComplexTypes.Tests/Types/EncoderTests.cs
+++ b/Tests/Opc.Ua.Client.ComplexTypes.Tests/Types/EncoderTests.cs
@@ -43,7 +43,7 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
     [Parallelizable]
     public class ComplexTypesEncoderTests : ComplexTypesCommon
     {
-        public ServiceMessageContext EncoderContext;
+        public IServiceMessageContext EncoderContext;
         public Dictionary<StructureType, (ExpandedNodeId, Type)> TypeDictionary;
 
         #region Test Setup

--- a/Tests/Opc.Ua.Core.Tests/Types/Encoders/EncoderCommon.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Encoders/EncoderCommon.cs
@@ -55,7 +55,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         protected const string ApplicationUri = "uri:localhost:opcfoundation.org:EncoderCommon";
         protected RandomSource RandomSource { get; private set; }
         protected DataGenerator DataGenerator { get; private set; }
-        protected ServiceMessageContext Context { get; private set; }
+        protected IServiceMessageContext Context { get; private set; }
         protected NamespaceTable NameSpaceUris { get; private set; }
         protected StringTable ServerUris { get; private set; }
 
@@ -318,7 +318,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         /// <returns></returns>
         protected IEncoder CreateEncoder(
             EncodingType encoderType,
-            ServiceMessageContext context,
+            IServiceMessageContext context,
             Stream stream,
             Type systemType,
             bool useReversibleEncoding = true,
@@ -351,7 +351,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         /// </summary>
         protected IDecoder CreateDecoder(
             EncodingType decoderType,
-            ServiceMessageContext context,
+            IServiceMessageContext context,
             Stream stream,
             Type systemType
             )

--- a/Tests/Opc.Ua.PubSub.Tests/Encoding/UadpDataSetMessageTests.cs
+++ b/Tests/Opc.Ua.PubSub.Tests/Encoding/UadpDataSetMessageTests.cs
@@ -389,7 +389,7 @@ namespace Opc.Ua.PubSub.Tests.Encoding
         /// <returns></returns>
         private void CompareEncodeDecode(UadpDataSetMessage uadpDataSetMessage)
         {
-            ServiceMessageContext messageContextEncode = new ServiceMessageContext();
+            IServiceMessageContext messageContextEncode = new ServiceMessageContext();
             BinaryEncoder encoder = new BinaryEncoder(messageContextEncode);
             uadpDataSetMessage.Encode(encoder);
             byte[] bytes = ReadBytes(encoder.BaseStream);


### PR DESCRIPTION
- use IServiceMessageContext where possible, make the implementation of encoders/decoders independent from client/server code